### PR TITLE
Fix bug with IMU init

### DIFF
--- a/Safety/Src/imu.cpp
+++ b/Safety/Src/imu.cpp
@@ -44,7 +44,6 @@ const double kAccelCorrector = 16384.0;
 IMU& MPU6050::getInstance(){
   static MPU6050 singleton; 
   return singleton; 
-
 }
 
 void MPU6050::GetResult(IMUData_t& Data){
@@ -84,6 +83,7 @@ void MPU6050::GetResult(IMUData_t& Data){
 
 MPU6050::MPU6050(){
   HAL_I2C_Init(&hi2c1);
+  ImuInit();
 }
 
 void MPU6050::ImuInit (void){


### PR DESCRIPTION
# Description

This PR initializes the MPU6050 driver, allowing for the device to be started and data to be read.

## Testing

This change was tested by flashing onto a dev board and waving the imu around and looking at the values in the debugger.

## Documentation

Simple bugfix, no need to update docs

# Merge Checklist:

- [x] The changes have been well commented, particularly in hard-to-understand areas.
- [x] The code has been tested on hardware, either by me or someone else.
- ~~[ ] Comprehensive unit tests have been made for this change~~
- ~~[ ] Corresponding changes to documentation have been created and links to this documentation are provided within the pull request.~~
- [x] The changes generate no new warnings and compile and run; A screenshot of a successful compile message is attached to the bottom of this PR.
